### PR TITLE
Fix row-count and decode bugs, speed up the reader, bump to 0.67

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ jn.sh
 *.iml
 *.sh
 **/*.lock
+!uv.lock
+.venv

--- a/README.md
+++ b/README.md
@@ -14,6 +14,34 @@ In the previous implementation, a `GeometryType` was defined using the UDT frame
 
 ### Changes
 
+- Version 0.67:
+  - `GDBIndex.indices` now clamps `startRow` and `numRows` to what the `.gdbtablx` actually holds.
+    An over-requested page previously ran off the end of the file and threw `EOFException` instead
+    of returning the rows that were there - `FileGDB#rows(numRowsToRead, startAtRow)` is a paging
+    API with no clamping of its own. This bug predates 0.66.
+  - `GDBTable.rows` returns an empty iterator when the header could not be parsed, rather than
+    scanning index slots of a file it already knows it cannot read.
+  - The index block buffer is positioned per row and sized by a byte budget, so a `numBytesPerRow`
+    outside 4..6 can no longer desynchronize the reader, and a garbage value can no longer be
+    amplified into an oversized allocation. Values outside 4..8 are now rejected outright.
+  - Header caches are keyed on path + length + modification time and capped, so regenerating a
+    `.gdb` at the same path no longer decodes new records with stale field offsets for the life
+    of the JVM.
+  - `FieldBinary` copies each blob once instead of twice.
+  - `--add-opens` moved into a `jdk9+` profile. The default build properties moved out of the
+    `activeByDefault` spark-3.5 profile to the top-level `<properties>` block, because Maven
+    deactivates `activeByDefault` profiles as soon as any other profile auto-activates.
+- Version 0.66:
+  - `FileGDB.rows(path, name, conf)` used to stop after `numFeatures` **index slots** rather than
+    scanning them all. On an edited (uncompacted) table, deleted rows occupy slots, so the call
+    silently returned only a fraction of the features. The Spark data source was never affected.
+  - `FieldBinary` returned a `ByteBuffer` view over a reused buffer for a `BinaryType` column -
+    now an `Array[Byte]` copy, which is what Spark actually expects. **Breaking** for code reading
+    a `BinaryType` column through the non-Spark `FileGDB.rows` / `FileGDB.apply` APIs, which hand
+    back the decoded value untouched: cast to `Array[Byte]`, not `ByteBuffer`.
+  - The `.gdbtable` / `.gdbtablx` header caches are now concurrent; several tasks share one executor JVM.
+  - `.gdbtablx` is read in 4096-row blocks, `getInt`/`getLong` in one call, and field bytes are bulk
+    copied. Roughly 1.4x on attribute-heavy tables, 1.1x when geometry decoding dominates.
 - Sep 10, 2021, Version 0.41 is a breaking change in the `FileGDB` object.
 
 ## Building the project using [Maven](https://maven.apache.org/):
@@ -26,19 +54,16 @@ mvn clean install
 
 The best demonstration of the usage of this implementation is with [PySpark DataFrames](https://docs.databricks.com/spark/latest/dataframes-datasets/introduction-to-dataframes-python.html) and in conjunction with the [ArcGIS API for Python](https://developers.arcgis.com/python/).
 
-Create a Python 3 [conda](https://conda.io/docs/) environment:
-
-```python
-conda remove --yes --all --name py36
-conda create --yes -n py36 -c conda-forge python=3.6 openjdk=8 findspark py4j
-```
+Create the local Python environment with [uv](https://docs.astral.sh/uv/) and smoke test the freshly
+built jar against a real File GeoDatabase:
 
 ```bash
-conda create --name arcgis python=3.6
-conda activate arcgis
-conda install -c esri arcgis
-conda install matplotlib
+uv sync
+uv run smoke_test.py /path/to/some.gdb
 ```
+
+`smoke_test.py` lists the feature classes, prints each schema, counts the rows, and checks that the
+decoded geometry falls inside the extent declared in the field metadata.
 
 Assuming that the environment variable `SPARK_HOME` points to the location of a Spark installation, start a Jupyter notebook that is backed by PySpark:
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,23 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <filegdb.version>0.65</filegdb.version>
-        <spark.compact>3.2</spark.compact>
-        <spark.version>${spark.compact}.1</spark.version>
+        <filegdb.version>0.67</filegdb.version>
         <revision>${filegdb.version}-${spark.compact}-${scala.compact}</revision>
+        <!--
+        Default build target. These live here rather than in an activeByDefault profile: Maven
+        deactivates activeByDefault profiles as soon as any other profile auto-activates, which
+        would silently break the build the moment the jdk9+ profile below kicks in. The spark-3.x
+        profiles override them when selected explicitly with -Pspark-3.3 / -Pspark-3.4.
+        -->
+        <java.version>1.8</java.version>
+        <scala.compact>2.12</scala.compact>
+        <scala.version>${scala.compact}.18</scala.version>
+        <scalatest.version>3.2.16</scalatest.version>
+        <spark.compact>3.5</spark.compact>
+        <spark.version>${spark.compact}.3</spark.version>
+        <spark.scope>provided</spark.scope>
+        <!-- Set by the jdk9+ profile; empty on JDK 8, which rejects the add-opens flag syntax. -->
+        <test.argLine/>
     </properties>
 
     <name>${project.artifactId}_${scala.compact}</name>
@@ -106,6 +119,7 @@
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>
                     <filereports>TestSuite.txt</filereports>
+                    <argLine>${test.argLine}</argLine>
                 </configuration>
                 <executions>
                     <execution>
@@ -223,19 +237,28 @@
                 <spark.scope>provided</spark.scope>
             </properties>
         </profile>
+        <!-- spark-3.5 is the default; its properties live in the top-level <properties> block. -->
         <profile>
-            <id>spark-3.5</id>
+            <!-- Spark reaches into JDK internals - without these the test JVM dies at startup. -->
+            <id>jdk9+</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <jdk>[9,)</jdk>
             </activation>
             <properties>
-                <java.version>1.8</java.version>
-                <scala.compact>2.12</scala.compact>
-                <scala.version>${scala.compact}.18</scala.version>
-                <scalatest.version>3.2.16</scalatest.version>
-                <spark.compact>3.5</spark.compact>
-                <spark.version>${spark.compact}.3</spark.version>
-                <spark.scope>provided</spark.scope>
+                <test.argLine>
+                    --add-opens=java.base/java.lang=ALL-UNNAMED
+                    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                    --add-opens=java.base/java.io=ALL-UNNAMED
+                    --add-opens=java.base/java.net=ALL-UNNAMED
+                    --add-opens=java.base/java.nio=ALL-UNNAMED
+                    --add-opens=java.base/java.util=ALL-UNNAMED
+                    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+                    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+                    --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+                    --add-opens=java.base/sun.security.action=ALL-UNNAMED
+                    --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+                </test.argLine>
             </properties>
         </profile>
         <!--profile>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "filegdb"
+version = "0.67"
+description = "PySpark harness for the com.esri filegdb Spark data source."
+requires-python = ">=3.10"
+dependencies = ["pyspark==3.5.3"]
+
+[tool.uv]
+package = false

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,0 +1,168 @@
+"""Smoke test the com.esri filegdb Spark data source against a real File GeoDatabase.
+
+Usage: uv run smoke_test.py [/path/to/some.gdb]
+"""
+
+import glob
+import os
+import struct
+import sys
+import time
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.types import StructType
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# A fixture shipped with the repo, so the no-argument form works for anyone who cloned it.
+DEFAULT_GDB = os.path.join(HERE, "data", "Miami.gdb")
+
+
+def find_jar() -> str:
+    jars = glob.glob(os.path.join(HERE, "target", "filegdb-*.jar"))
+    jars = [j for j in jars if "sources" not in j and "javadoc" not in j]
+    if not jars:
+        sys.exit("No filegdb jar in target/ - run 'mvn clean install -DskipTests' first.")
+    # Newest, not lexicographically last: target/ accumulates jars across spark profiles and
+    # version bumps, and picking the wrong one silently validates code that was not just built.
+    return max(jars, key=os.path.getmtime)
+
+
+def gdb_module(spark: SparkSession):
+    """The Scala FileGDB object, through py4j.
+
+    A Scala object with a companion class emits no static forwarders, so the
+    MODULE$ singleton has to be reached by name.
+    """
+    return getattr(getattr(spark.sparkContext._jvm.com.esri.gdb, "FileGDB$"), "MODULE$")
+
+
+def is_compressed(spark: SparkSession, gdb: str, name: str) -> bool:
+    """A .gdbtable signature other than 3 means a compressed table, which this reader
+    does not support - so an empty schema there is a documented limit, not a failure."""
+    opt = gdb_module(spark).findTable(gdb, name, spark.sparkContext._jsc.hadoopConfiguration())
+    if not opt.isDefined():
+        return False
+    path = os.path.join(gdb, opt.get().toTableName() + ".gdbtable")
+    if not os.path.exists(path):
+        return False
+    with open(path, "rb") as fp:
+        return struct.unpack("<i", fp.read(4))[0] != 3
+
+
+def main() -> None:
+    gdb = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_GDB
+    if not os.path.isdir(gdb):
+        sys.exit(f"Not a directory: {gdb}")
+    jar = find_jar()
+    print(f"jar={os.path.basename(jar)}\ngdb={gdb}\n")
+
+    spark = (
+        SparkSession.builder.appName("filegdb-smoke")
+        .master("local[*]")
+        .config("spark.jars", jar)
+        .config("spark.driver.memory", "4g")
+        .config("spark.sql.session.timeZone", "UTC")
+        .config("spark.ui.enabled", "false")
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("WARN")
+
+    failures, skipped = [], []
+    try:
+        conf = spark.sparkContext._jsc.hadoopConfiguration()
+        all_names = list(gdb_module(spark).listTableNames(gdb, conf))
+        names = [n for n in all_names if not n.startswith("GDB_")]
+        print(f"--- {len(names)} table(s): {names}\n")
+        if not names:
+            failures.append("catalog listed no user tables")
+
+        for name in names:
+            print(f"=== {name}")
+            df = spark.read.format("gdb").option("path", gdb).option("name", name).load()
+            if not df.schema.fields:
+                if is_compressed(spark, gdb, name):
+                    print("SKIP: compressed table, unsupported by this reader\n")
+                    skipped.append(f"{name}: compressed")
+                else:
+                    failures.append(f"{name}: empty schema")
+                continue
+            df.printSchema()
+
+            t0 = time.time()
+            n = df.count()
+            elapsed = time.time() - t0
+            print(f"rows={n} in {elapsed:.2f}s ({n / max(elapsed, 1e-9):,.0f} rows/s)")
+
+            # GDBTableIterator catches any decode error per row and emits every field as null, so a
+            # partial decode failure is invisible to a count or a min/max. A row that decoded
+            # cleanly always has its non-nullable columns populated - OBJECTID at minimum.
+            required = [f.name for f in df.schema.fields if not f.nullable]
+            if required and n:
+                pred = F.lit(False)
+                for c in required:
+                    pred = pred | F.col(f"`{c}`").isNull()
+                bad = df.filter(pred).count()
+                if bad:
+                    failures.append(
+                        f"{name}: {bad} of {n} row(s) NULL in a non-nullable column {required}"
+                        " - rows failed to decode"
+                    )
+
+            shape = next(
+                (f.name for f in df.schema.fields if "geomType" in f.metadata), None
+            )
+            shape_type = df.schema[shape].dataType if shape else None
+            if shape and not isinstance(shape_type, StructType):
+                # Unsupported geometry types fall back to FieldGeomNoop, a StringType column that
+                # still carries the geometry metadata. Nothing to validate, and no sub-fields.
+                print(f"shape={shape} is {shape_type.simpleString()}, unsupported geometry - not validated")
+            elif shape and n == 0:
+                print(f"shape={shape} skipped, table is empty")
+            elif shape:
+                meta = df.schema[shape].metadata
+                sub = shape_type.fieldNames()
+                # Point shapes carry x/y, everything else carries an xmin..ymax envelope.
+                xcol, ycol = ("xmin", "ymin") if "xmin" in sub else ("x", "y")
+                xhi, yhi_col = ("xmax", "ymax") if "xmax" in sub else ("x", "y")
+                # min/max forces a full decode of every geometry in the table.
+                agg = df.selectExpr(
+                    f"min(`{shape}`.{xcol}) as xlo", f"max(`{shape}`.{xhi}) as xhi",
+                    f"min(`{shape}`.{ycol}) as ylo", f"max(`{shape}`.{yhi_col}) as yhi",
+                ).first()
+                print(
+                    f"shape={shape} meta_extent="
+                    f"({meta['xmin']:.4f}, {meta['ymin']:.4f}, {meta['xmax']:.4f}, {meta['ymax']:.4f})"
+                    f" data=({agg['xlo']}, {agg['ylo']}, {agg['xhi']}, {agg['yhi']})"
+                )
+                if agg["xlo"] is None:
+                    failures.append(f"{name}: all geometries decoded to null")
+                else:
+                    # Both axes, both bounds - a swapped or corrupted Y is exactly the kind of
+                    # regression the decode rewrites could introduce, and X alone would miss it.
+                    for label, value, lo, hi in (
+                        ("x", agg["xlo"], meta["xmin"], meta["xmax"]),
+                        ("x", agg["xhi"], meta["xmin"], meta["xmax"]),
+                        ("y", agg["ylo"], meta["ymin"], meta["ymax"]),
+                        ("y", agg["yhi"], meta["ymin"], meta["ymax"]),
+                    ):
+                        if value is None or not (lo - 1e-6 <= value <= hi + 1e-6):
+                            failures.append(
+                                f"{name}: decoded {label} {value} outside declared extent [{lo}, {hi}]"
+                            )
+
+            df.show(3, truncate=40, vertical=True)
+            print()
+    finally:
+        spark.stop()
+
+    if skipped:
+        print("SKIPPED:\n  " + "\n  ".join(skipped))
+    if failures:
+        print("FAIL:\n  " + "\n  ".join(failures))
+        sys.exit(1)
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main/scala/com/esri/gdb/DataBuffer.scala
+++ b/src/main/scala/com/esri/gdb/DataBuffer.scala
@@ -29,37 +29,11 @@ class DataBuffer(dataInput: FSDataInputStream) extends AutoCloseable with Serial
     this
   }
 
-//  def position(seek: Long): DataBuffer = {
-//    dataInput.seek(seek)
-//    this
-//  }
+  // The GDB format is little-endian, DataInput is big-endian - hence the byte reversal.
+  // One readInt/readLong beats 4/8 readByte calls through the FSDataInputStream stack.
+  def getInt(): Int = Integer.reverseBytes(dataInput.readInt())
 
-  @inline
-  private def fromBytes(b1: Byte, b2: Byte, b3: Byte, b4: Byte): Int = b1 << 24 | (b2 & 255) << 16 | (b3 & 255) << 8 | b4 & 255
-
-  def getInt(): Int = {
-    val b1 = dataInput.readByte()
-    val b2 = dataInput.readByte()
-    val b3 = dataInput.readByte()
-    val b4 = dataInput.readByte()
-    /*Ints.*/ fromBytes(b4, b3, b2, b1)
-  }
-
-  @inline
-  private def fromBytes(b1: Byte, b2: Byte, b3: Byte, b4: Byte, b5: Byte, b6: Byte, b7: Byte, b8: Byte): Long =
-    (b1 & 0xFFL) << 56 | (b2 & 0xFFL) << 48 | (b3 & 0xFFL) << 40 | (b4 & 0xFFL) << 32 | (b5 & 0xFFL) << 24 | (b6 & 0xFFL) << 16 | (b7 & 0xFFL) << 8 | (b8 & 0xFFL)
-
-  def getLong(): Long = {
-    val b1 = dataInput.readByte()
-    val b2 = dataInput.readByte()
-    val b3 = dataInput.readByte()
-    val b4 = dataInput.readByte()
-    val b5 = dataInput.readByte()
-    val b6 = dataInput.readByte()
-    val b7 = dataInput.readByte()
-    val b8 = dataInput.readByte()
-    /*Longs.*/ fromBytes(b8, b7, b6, b5, b4, b3, b2, b1)
-  }
+  def getLong(): Long = java.lang.Long.reverseBytes(dataInput.readLong())
 
   def close(): Unit = {
     dataInput.close()

--- a/src/main/scala/com/esri/gdb/GDBField.scala
+++ b/src/main/scala/com/esri/gdb/GDBField.scala
@@ -74,23 +74,34 @@ class FieldUUID(val field: StructField) extends GDBField {
   override type T = String
 
   private val b = new Array[Byte](16)
+  private val sb = new java.lang.StringBuilder(38)
 
   def readNull(): String = null
 
+  private def hex(i: Int): Unit = {
+    val v = b(i) & 0xFF
+    sb.append(FieldUUID.Hex(v >> 4)).append(FieldUUID.Hex(v & 0x0F))
+  }
+
+  // Hand-rolled - String.format re-parses its 16-arg pattern on every single row.
   override def readValue(byteBuffer: ByteBuffer, oid: Int): String = {
-    var n = 0
-    while (n < 16) {
-      b(n) = byteBuffer.get
-      n += 1
-    }
-    "{%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X}".format(
-      b(3), b(2), b(1), b(0),
-      b(5), b(4), b(7), b(6),
-      b(8), b(9), b(10), b(11),
-      b(12), b(13), b(14), b(15))
+    byteBuffer.get(b, 0, 16)
+    sb.setLength(0)
+    sb.append('{')
+    hex(3); hex(2); hex(1); hex(0); sb.append('-')
+    hex(5); hex(4); sb.append('-')
+    hex(7); hex(6); sb.append('-')
+    hex(8); hex(9); sb.append('-')
+    hex(10); hex(11); hex(12); hex(13); hex(14); hex(15)
+    sb.append('}')
+    sb.toString
   }
 
   override def copy(): GDBField = new FieldUUID(field)
+}
+
+object FieldUUID {
+  private val Hex = "0123456789ABCDEF".toCharArray
 }
 
 class FieldTimestamp(val field: StructField) extends GDBField {
@@ -139,11 +150,7 @@ abstract class FieldBytes extends GDBField {
     if (numBytes > m_bytes.length) {
       m_bytes = new Array[Byte](numBytes)
     }
-    var n = 0
-    while (n < numBytes) {
-      m_bytes(n) = byteBuffer.get
-      n += 1
-    }
+    byteBuffer.get(m_bytes, 0, numBytes) // Bulk copy, not a byte at a time.
     numBytes
   }
 
@@ -155,12 +162,17 @@ abstract class FieldBytes extends GDBField {
 }
 
 class FieldBinary(val field: StructField) extends FieldBytes {
-  override type T = ByteBuffer
+  // BinaryType maps to Array[Byte] in Spark, and the value has to outlive the shared m_bytes buffer.
+  override type T = Array[Byte]
 
-  def readNull(): ByteBuffer = null.asInstanceOf[ByteBuffer]
+  def readNull(): Array[Byte] = null
 
-  override def readValue(byteBuffer: ByteBuffer, oid: Int): ByteBuffer = {
-    getByteBuffer(byteBuffer)
+  // Straight into the result: going via fillVarBytes would copy every blob twice and pin the
+  // shared m_bytes at the size of the largest blob in the table for the life of the task.
+  override def readValue(byteBuffer: ByteBuffer, oid: Int): Array[Byte] = {
+    val bytes = new Array[Byte](byteBuffer.getVarUInt().toInt)
+    byteBuffer.get(bytes)
+    bytes
   }
 
   override def copy(): GDBField = new FieldBinary(field)

--- a/src/main/scala/com/esri/gdb/GDBIndex.scala
+++ b/src/main/scala/com/esri/gdb/GDBIndex.scala
@@ -152,11 +152,12 @@ object GDBIndex extends Serializable {
       val numPages = byteBuffer.getInt // A page has 1024 rows.
       val numRows = byteBuffer.getInt
       val numBytesPerRow = byteBuffer.getInt
-      // The spec only ever uses 4, 5 or 6. Anything else means this is not a .gdbtablx we can read,
-      // and letting it through would size the block buffer off a garbage number.
-      if (numBytesPerRow < 4 || numBytesPerRow > 8) {
+      // Only 4, 5 and 6 have a SeekReader; anything else would fall through to SeekReader4 and
+      // decode offsets from the wrong bytes. A hard error beats silently wrong geometry. (7 and 8
+      // byte rows show up in the V4 / 64-bit OBJECTID format, which this reader does not support.)
+      if (numBytesPerRow < 4 || numBytesPerRow > 6) {
         throw new RuntimeException(
-          s"'$filename' reports $numBytesPerRow bytes per row, expected 4 to 8. Not a readable index.")
+          s"'$filename' reports $numBytesPerRow bytes per row, expected 4 to 6. Not a readable index.")
       }
       GDBIndexHeader(version, numPages, numRows, numBytesPerRow)
     }

--- a/src/main/scala/com/esri/gdb/GDBIndex.scala
+++ b/src/main/scala/com/esri/gdb/GDBIndex.scala
@@ -7,8 +7,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.util.TaskCompletionListener
 import org.slf4j.LoggerFactory
 
-import java.nio.{ByteBuffer, ByteOrder}
-import scala.collection.mutable
+import java.nio.{Buffer, ByteBuffer, ByteOrder}
+import scala.collection.concurrent.TrieMap
 
 private[gdb] trait SeekReader extends Serializable {
   def readSeek(byteBuffer: ByteBuffer): Long
@@ -37,7 +37,10 @@ private[gdb] class GDBIndexIterator(dataInput: FSDataInputStream,
     with Logging
     with Serializable {
 
-  private val bytes = new Array[Byte](numBytesPerRow)
+  // Read the index in blocks rather than one 4-6 byte row per readFully call. The block is sized
+  // by a byte budget, not a row count, so a bogus numBytesPerRow cannot blow up the allocation.
+  private val rowsPerBlock = ((GDBIndexIterator.BlockBytes / numBytesPerRow) min maxRows) max 1
+  private val bytes = new Array[Byte](rowsPerBlock * numBytesPerRow)
   private val byteBuffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
   private val seekReader = numBytesPerRow match {
     case 5 => new SeekReader5()
@@ -46,14 +49,24 @@ private[gdb] class GDBIndexIterator(dataInput: FSDataInputStream,
   }
   private var objectID = startID
   private var numRows = 0
+  private var rowInBlock = 0
+  private var rowsInBlock = 0
   private var seek = 0L
 
   def hasNext(): Boolean = {
     while (seek == 0L && numRows < maxRows) {
+      if (rowInBlock == rowsInBlock) {
+        rowsInBlock = rowsPerBlock min (maxRows - numRows)
+        rowInBlock = 0
+        dataInput.readFully(bytes, 0, rowsInBlock * numBytesPerRow)
+      }
+      // Position per row: a SeekReader may consume fewer bytes than the on-disk row stride, so
+      // letting the buffer position just run on would desynchronize it from the slot boundaries.
+      // Widened to Buffer - ByteBuffer.position(int) is covariant from Java 9 and breaks on 8.
+      (byteBuffer: Buffer).position(rowInBlock * numBytesPerRow)
+      rowInBlock += 1
       numRows += 1
       objectID += 1
-      byteBuffer.clear()
-      dataInput.readFully(bytes, 0, numBytesPerRow)
       seek = seekReader.readSeek(byteBuffer) // 0 value indicates that the row is deleted.
     }
     seek > 0L
@@ -70,6 +83,10 @@ private[gdb] class GDBIndexIterator(dataInput: FSDataInputStream,
   }
 }
 
+private[gdb] object GDBIndexIterator {
+  val BlockBytes = 32768
+}
+
 class GDBIndex(dataInput: FSDataInputStream,
                header: GDBIndexHeader,
                context: Option[TaskContext]
@@ -79,10 +96,20 @@ class GDBIndex(dataInput: FSDataInputStream,
 
   def maxRows: Int = header.maxRows
 
-  def indices(numRows: Int = header.numRows, startRow: Int = 0): Iterator[GDBIndexRow] = {
-    // logger.debug(s"indices::numRows=$numRows numBytesPerRow=${header.numBytesPerRow} startRow=$startRow")
-    dataInput.seek(16L + startRow * header.numBytesPerRow)
-    val iterator = new GDBIndexIterator(dataInput, startRow, numRows, header.numBytesPerRow)
+  /**
+   * @param numRows the number of index slots to scan, -1 for every slot from startRow on.
+   * @param startRow the slot to start at.
+   *
+   * Both are clamped to what the file actually holds - an over-requested page used to run off the
+   * end of the .gdbtablx and throw EOFException instead of returning the rows that were there.
+   */
+  def indices(numRows: Int = -1, startRow: Int = 0): Iterator[GDBIndexRow] = {
+    val start = startRow max 0 min header.maxRows
+    val available = header.maxRows - start
+    val rows = (if (numRows < 0) available else numRows) min available max 0
+    // logger.debug(s"indices::rows=$rows numBytesPerRow=${header.numBytesPerRow} start=$start")
+    dataInput.seek(16L + start.toLong * header.numBytesPerRow)
+    val iterator = new GDBIndexIterator(dataInput, start, rows, header.numBytesPerRow)
     if (context.isDefined) {
       context.get.addTaskCompletionListener(iterator)
     }
@@ -106,13 +133,15 @@ case class GDBIndexHeader(version: Int, numPages: Int, numRows: Int, numBytesPer
 
 object GDBIndex extends Serializable {
 
-  private val map = mutable.Map.empty[String, GDBIndexHeader]
+  // Concurrent - executors run several tasks against the same JVM.
+  private val map = TrieMap.empty[String, GDBIndexHeader]
 
   def apply(conf: Configuration, path: String, name: String, context: Option[TaskContext] = None): GDBIndex = {
     val logger = LoggerFactory.getLogger(getClass)
-    val filename = StringBuilder.newBuilder.append(path).append("/").append(name).append(".gdbtablx").toString()
+    val filename = s"$path/$name.gdbtablx"
     val hdfsPath = new Path(filename)
-    val dataInput = hdfsPath.getFileSystem(conf).open(hdfsPath)
+    val fileSystem = hdfsPath.getFileSystem(conf)
+    val dataInput = fileSystem.open(hdfsPath)
 
     def readHeader: GDBIndexHeader = {
       logger.debug(s"Cache $filename...")
@@ -123,10 +152,16 @@ object GDBIndex extends Serializable {
       val numPages = byteBuffer.getInt // A page has 1024 rows.
       val numRows = byteBuffer.getInt
       val numBytesPerRow = byteBuffer.getInt
+      // The spec only ever uses 4, 5 or 6. Anything else means this is not a .gdbtablx we can read,
+      // and letting it through would size the block buffer off a garbage number.
+      if (numBytesPerRow < 4 || numBytesPerRow > 8) {
+        throw new RuntimeException(
+          s"'$filename' reports $numBytesPerRow bytes per row, expected 4 to 8. Not a readable index.")
+      }
       GDBIndexHeader(version, numPages, numRows, numBytesPerRow)
     }
 
-    val header = map.getOrElseUpdate(filename, readHeader)
+    val header = cachedHeader(map, cacheKey(fileSystem, hdfsPath), readHeader)
     new GDBIndex(dataInput, header, context)
   }
 

--- a/src/main/scala/com/esri/gdb/GDBTable.scala
+++ b/src/main/scala/com/esri/gdb/GDBTable.scala
@@ -9,18 +9,20 @@ import org.apache.spark.util.TaskCompletionListener
 import org.slf4j.LoggerFactory
 
 import java.nio.ByteBuffer
-import scala.collection.mutable
+import scala.collection.concurrent.TrieMap
 
 case class GDBTableHeader(numFeatures: Int, largestSize: Int, fields: Array[GDBField])
 
 object GDBTable extends Serializable {
   private val logger = LoggerFactory.getLogger(getClass)
-  private val map = mutable.Map.empty[String, GDBTableHeader]
+  // Concurrent - executors run several tasks against the same JVM.
+  private val map = TrieMap.empty[String, GDBTableHeader]
 
   def apply(conf: Configuration, path: String, name: String, context: Option[TaskContext] = None): GDBTable = {
-    val filename = StringBuilder.newBuilder.append(path).append("/").append(name).append(".gdbtable").toString()
+    val filename = s"$path/$name.gdbtable"
     val hdfsPath = new Path(filename)
-    val dataInput = hdfsPath.getFileSystem(conf).open(hdfsPath)
+    val fileSystem = hdfsPath.getFileSystem(conf)
+    val dataInput = fileSystem.open(hdfsPath)
     val dataBuffer = DataBuffer(dataInput)
 
     def readTableHeader: GDBTableHeader = {
@@ -69,7 +71,7 @@ object GDBTable extends Serializable {
       }
     }
 
-    val tableHeader = map.getOrElseUpdate(filename, readTableHeader)
+    val tableHeader = cachedHeader(map, cacheKey(fileSystem, hdfsPath), readTableHeader)
     new GDBTable(dataBuffer, tableHeader, context)
   }
 
@@ -380,7 +382,15 @@ class GDBTable(dataBuffer: DataBuffer,
 
   val schema: StructType = StructType(header.fields.map(_.field))
 
-  def rows(index: GDBIndex, numRows: Int = header.numFeatures, startAtRow: Int = 0): Iterator[Row] = {
+  /**
+   * @param numRows the number of index *slots* to scan, -1 for every slot from startAtRow on.
+   *                Deleted rows still occupy slots, so header.numFeatures (a live-row count) would
+   *                truncate an uncompacted table. GDBIndex.indices clamps both arguments.
+   */
+  def rows(index: GDBIndex, numRows: Int = -1, startAtRow: Int = 0): Iterator[Row] = {
+    // An unreadable header (compressed table, wrong signature) yields no fields. Scanning the index
+    // anyway would decode garbage record lengths out of a file we already know we cannot parse.
+    if (header.fields.isEmpty) return Iterator.empty
     val fieldsCopy = header.fields.map(_.copy())
     val iterator = new GDBTableIterator(index.indices(numRows, startAtRow), dataBuffer, fieldsCopy)
     if (context.isDefined) {

--- a/src/main/scala/com/esri/gdb/GDBTableIterator.scala
+++ b/src/main/scala/com/esri/gdb/GDBTableIterator.scala
@@ -29,27 +29,30 @@ class GDBTableIterator(indexIter: Iterator[GDBIndexRow],
       nullValueMasks(n) = byteBuffer.get
       n += 1
     }
-    var bit = 0
-    val values: Array[Any] = try {
-      fields.map(field => {
-        if (field.nullable) {
-          val i = bit >> 3
-          val m = 1 << (bit & 7)
+    // Filled in place - a closure over a `var bit` would box the counter on every row.
+    val values = new Array[Any](fields.length)
+    try {
+      var bit = 0
+      var f = 0
+      while (f < fields.length) {
+        val field = fields(f)
+        values(f) = if (field.nullable) {
+          val isNull = (nullValueMasks(bit >> 3) & (1 << (bit & 7))) != 0
           bit += 1
-          if ((nullValueMasks(i) & m) == 0) {
-            field.readValue(byteBuffer, index.oid)
-          }
-          else {
-            field.readNull()
-          }
+          if (isNull) field.readNull() else field.readValue(byteBuffer, index.oid)
         } else {
           field.readValue(byteBuffer, index.oid)
         }
-      })
+        f += 1
+      }
     } catch {
       case t: Throwable =>
         logger.error(s"OBJECTID=${index.oid}, numBytes=$numBytes", t)
-        fields.map(_.readNull())
+        var f = 0
+        while (f < fields.length) {
+          values(f) = fields(f).readNull()
+          f += 1
+        }
     }
     // new GenericRowWithSchema(values, schema)
     // rows += 1

--- a/src/main/scala/com/esri/gdb/package.scala
+++ b/src/main/scala/com/esri/gdb/package.scala
@@ -1,12 +1,33 @@
 package com.esri
 
+import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{DataFrame, DataFrameReader, SQLContext}
 import org.apache.spark.util.SerializableConfiguration
 
 import java.nio.ByteBuffer
+import scala.collection.concurrent.TrieMap
 
 package object gdb {
+
+  /**
+   * Header cache key: path plus length and modification time. Keying on the path alone meant a
+   * .gdb regenerated at the same path kept decoding new records with the old field offsets for
+   * the life of the JVM, with no way to invalidate short of a restart.
+   */
+  private[gdb] def cacheKey(fileSystem: FileSystem, path: Path): String = {
+    val status = fileSystem.getFileStatus(path)
+    s"${path.toUri}:${status.getLen}:${status.getModificationTime}"
+  }
+
+  // ponytail: flat cap, not an LRU. Entries are tiny and only accumulate when a file is rewritten
+  // in a long-lived JVM; swap in a real eviction policy if that ever turns out to matter.
+  private[gdb] val MaxCachedHeaders = 256
+
+  private[gdb] def cachedHeader[T](map: TrieMap[String, T], key: String, read: => T): T = {
+    if (map.size > MaxCachedHeaders) map.clear()
+    map.getOrElseUpdate(key, read)
+  }
 
   implicit class SparkContextImplicits(val sc: SparkContext) extends AnyVal {
     def gdb(path: String,

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,32 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "filegdb"
+version = "0.67"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyspark" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyspark", specifier = "==3.5.3" }]
+
+[[package]]
+name = "py4j"
+version = "0.10.9.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/f2/b34255180c72c36ff7097f7c2cdca02abcbd89f5eebf7c7c41262a9a0637/py4j-0.10.9.7.tar.gz", hash = "sha256:0b6e5315bb3ada5cf62ac651d107bb2ebc02def3dee9d9548e3baac644ea8dbb", size = 1508234, upload-time = "2022-08-12T22:49:09.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/30/a58b32568f1623aaad7db22aa9eafc4c6c194b429ff35bdc55ca2726da47/py4j-0.10.9.7-py2.py3-none-any.whl", hash = "sha256:85defdfd2b2376eb3abf5ca6474b51ab7e0de341c75a02f46dc9b5976f5a5c1b", size = 200481, upload-time = "2022-08-12T22:49:07.05Z" },
+]
+
+[[package]]
+name = "pyspark"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py4j" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/90/cb80c8cf194958ab9a3242851c62fa5aef1a0b42f2d9642f1e2eca098005/pyspark-3.5.3.tar.gz", hash = "sha256:68b7cc0c0c570a7d8644f49f40d2da8709b01d30c9126cc8cf93b4f84f3d9747", size = 317304325, upload-time = "2024-09-24T00:28:04.861Z" }


### PR DESCRIPTION
## Summary

Fixes a set of correctness bugs in the File GeoDatabase reader, speeds up the hot decode paths, and adds a runnable smoke-test harness. Version 0.65 → 0.67.

The headline bug: `FileGDB.rows(path, name, conf)` stopped after `numFeatures` index **slots** rather than scanning them all. `numFeatures` counts live rows, but deleted rows still occupy slots, so on an edited (uncompacted) table the call silently returned a fraction of the data — `Miami.gdb` `Broadcast` returned **162,970 of 1,365,578** rows. The Spark data source was never affected, since `GDBRDD` always passes an explicit slot count.

## Correctness

| Fix | Impact |
|---|---|
| `FileGDB.rows` slot-count bug | Silently returned 12% of an uncompacted table |
| `GDBIndex.indices` missing clamp | Over-requested page threw `EOFException` instead of returning its rows. Predates this branch |
| `FieldBinary` returned `ByteBuffer` | Wrong type for Spark's `BinaryType`, and the view aliased a reused buffer that mutated on the next row |
| Header caches were plain `mutable.Map` | `getOrElseUpdate` race across tasks sharing an executor JVM |
| Header caches keyed on path only | A `.gdb` regenerated at the same path decoded at stale field offsets for the life of the JVM |
| Unparsable header still scanned | Now short-circuits to an empty iterator |
| Index block buffer alignment | A `numBytesPerRow` outside 4..6 could desync the reader or drive an oversized allocation |
| `startRow * numBytesPerRow` | Int overflow past ~536M rows |

## Performance

One `readInt`/`readLong` + `reverseBytes` instead of 4/8 `readByte` calls; `.gdbtablx` read in blocks rather than one `readFully` per 4-6 byte row; bulk copies in `fillVarBytes`; a preallocated array + while loop in `GDBTableIterator.next` (the old `fields.map` closed over a `var`, boxing per row); hand-rolled hex in `FieldUUID`.

Measured min-of-9 on `data/Miami.gdb`: **1.42×** on attribute-heavy `Voyage`, **1.08×** on geometry-heavy `Broadcast` where decoding dominates.

## Build and tooling

The scalatest JVM had been dying at startup on JDK 17 (`IllegalAccessError` on `sun.nio.ch.DirectBuffer`) — no test was running at all. Fixed with a `jdk9+` profile carrying the `--add-opens` flags. That required moving the default build properties out of the `activeByDefault` spark-3.5 profile, since Maven deactivates `activeByDefault` profiles the moment any other profile auto-activates. **Test suite goes from aborting to 5 passing.**

Adds `pyproject.toml` / `uv.lock` (pyspark 3.5.3, matching the pom) and `smoke_test.py`:

```bash
uv sync
uv run smoke_test.py /path/to/some.gdb
```

It lists the feature classes, counts rows, forces a full geometry decode, asserts the decoded extent falls inside the declared field metadata **on both axes**, and detects rows that hit `GDBTableIterator`'s blanket catch by checking for NULLs in non-nullable columns.

## Breaking change

`FieldBinary.readValue` now returns `Array[Byte]` instead of `ByteBuffer`. Source- and binary-incompatible for code reading a `BinaryType` column through the non-Spark `FileGDB.rows` / `FileGDB.apply` APIs, which hand the decoded value back untouched. The old behaviour was already broken for the Spark path. Flagged as worth a minor bump rather than a patch; shipping as 0.67 per author's call, documented in the README changelog.

## Test plan

- `mvn clean install` — 5 tests pass, 0 fail (previously the suite aborted)
- `uv run smoke_test.py` against `data/Miami.gdb` (7 tables), `NorthSea.gdb` (3), `PACI.gdb` (7, 1.3 GB) — all OK, including PACI's projected-CRS layer and the 1.6M-row `Master` table
- Paging regression re-checked directly: the four calls that previously threw `EOFException` now return 188583 / 187583 / 3583 / 187583 rows

## Not covered

The only compressed-table fixture available (`PACI.gdb/H3Level10`, signature 4) was deleted by an external edit to that geodatabase mid-review, so the compressed-table skip path and the unparsable-header short-circuit have no live smoke-test coverage. Both are still exercised in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156SHAMbAg8Jfb1janY5ahk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 0.67 with support for Spark 3.5 and Python 3.10+ environments.
  * Binary field values are now returned as byte arrays.

* **Bug Fixes**
  * Improved decoding reliability for binary data, nullable fields, schemas, and geometry values.
  * Prevented stale data when geodatabases are modified.
  * Improved handling of unreadable or compressed tables.

* **Performance**
  * Accelerated index and table reading through optimized block processing.

* **Documentation**
  * Added `uv` setup instructions and a real geodatabase smoke-test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->